### PR TITLE
Allow using either a config file or cli flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,10 +241,47 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "4.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -614,6 +651,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -1052,6 +1095,12 @@ dependencies = [
  "dlv-list",
  "hashbrown",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "overload"
@@ -1727,10 +1776,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bson",
+ "clap 4.0.26",
+ "config",
  "humantime",
  "paho-mqtt",
+ "serde",
  "spectacles",
- "structopt",
 ]
 
 [[package]]
@@ -1740,6 +1791,7 @@ dependencies = [
  "anyhow",
  "bson",
  "bytes",
+ "clap 4.0.26",
  "config",
  "futures",
  "nanoid",
@@ -1763,12 +1815,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "structopt-derive",
 ]
@@ -1779,7 +1837,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1815,6 +1873,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2446,6 +2513,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/brokers/mqtt/Cargo.toml
+++ b/brokers/mqtt/Cargo.toml
@@ -13,5 +13,5 @@ clap = { version = "4.0.26", features = ["derive", "env"] }
 config = "0.13.2"
 humantime = "2.1.0"
 paho-mqtt = "0.11.1"
-serde = "1.0.147"
+serde = { version = "1.0.147", features = ["derive"] }
 spectacles = { version = "0.1.0", path = "../.." }

--- a/brokers/mqtt/Cargo.toml
+++ b/brokers/mqtt/Cargo.toml
@@ -9,7 +9,9 @@ description = "Proxy STDIO with an MQTT server using BSON."
 [dependencies]
 anyhow = "1.0.66"
 bson = "2.4.0"
+clap = { version = "4.0.26", features = ["derive", "env"] }
+config = "0.13.2"
 humantime = "2.1.0"
 paho-mqtt = "0.11.1"
+serde = "1.0.147"
 spectacles = { version = "0.1.0", path = "../.." }
-structopt = "0.3.26"

--- a/brokers/mqtt/src/config.rs
+++ b/brokers/mqtt/src/config.rs
@@ -27,7 +27,7 @@ pub struct Config {
 	pub connect: ConnectOpt,
 
 	/// Events to subscribe to.
-	#[arg(long, env = "MQTT_EVENTS", value_delimiter = ',')]
+	#[arg(short, long, env = "MQTT_EVENTS", value_delimiter = ',')]
 	pub events: Vec<String>,
 
 	/// Quality of Service for sending & receiving messages
@@ -77,7 +77,7 @@ impl Config {
 #[derive(Debug, Serialize, Deserialize, Parser)]
 pub struct CreateOpt {
 	/// The URL of the MQTT server.
-	#[arg(short, long, env = "MQTT_URL", default_value = "localhost:1883")]
+	#[arg(long, env = "MQTT_URL", default_value = "localhost:1883")]
 	pub url: String,
 
 	/// The client ID useful for session resuming

--- a/brokers/mqtt/src/config.rs
+++ b/brokers/mqtt/src/config.rs
@@ -1,42 +1,91 @@
 use std::{path::PathBuf, time::Duration};
-
+use anyhow::Result;
+use clap::{Parser};
+use config;
 use humantime::parse_duration;
 use paho_mqtt::{
-	ConnectOptions, ConnectOptionsBuilder, CreateOptions, CreateOptionsBuilder, Error, SslOptions,
+	ConnectOptions,
+	ConnectOptionsBuilder,
+	CreateOptions,
+	CreateOptionsBuilder,
+	Error,
+	SslOptions,
 	SslOptionsBuilder,
 };
-use structopt::StructOpt;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "spectacles-mqtt", about = env!("CARGO_PKG_DESCRIPTION"))]
-pub struct Opt {
-	#[structopt(flatten)]
+#[derive(Debug, Serialize, Deserialize, Parser)]
+#[command(name = "spectacles-redis", about = env!("CARGO_PKG_DESCRIPTION"))]
+pub struct Config {
+	#[arg(long, short, env = "MQTT_CONFIG_FILE", exclusive = true)]
+	pub config_file: Option<String>,
+
+	#[command(flatten)]
 	pub create: CreateOpt,
-	#[structopt(flatten)]
+
+	#[command(flatten)]
 	pub connect: ConnectOpt,
+
 	/// Events to subscribe to.
-	#[structopt(long)]
+	#[arg(long, env = "MQTT_EVENTS", value_delimiter = ',')]
 	pub events: Vec<String>,
+
 	/// Quality of Service for sending & receiving messages
 	/// - 0: At most once
 	/// - 1: At least once
 	/// - 2: Exactly once
-	#[structopt(long, default_value = "2")]
+	#[arg(long, env = "MQTT_QOS", default_value = "2")]
 	pub qos: i32,
 }
 
-#[derive(Debug, StructOpt)]
+impl Config {
+	pub fn build() -> Result<Config> {
+		let opt = Config::parse();
+
+		if let Some(config_file) = opt.config_file {
+			let file_source = config::File::with_name(&config_file)
+				.required(false);
+
+			let env_source = config::Environment::with_prefix("MQTT")
+				.try_parsing(true)
+				.list_separator(",")
+				.with_list_parse_key("events");
+
+			let config: Config = config::Config::builder()
+				.add_source(file_source)
+				.add_source(env_source)
+				.set_default("events", vec![] as Vec<String>)?
+				.set_default("qos", 2)?
+				.set_default("create.url", "localhost:1883")?
+				.set_default("create.client_id", "")?
+				.set_default("create.mqtt_version", 5)?
+				.set_default("connect.clean_session", false)?
+				.set_default("connect.clean_start", false)?
+				.set_default("connect.ssl.enable_server_cert_auth", false)?
+				.set_default("connect.ssl.verify", false)?
+				.set_default("connect.ssl.disable_default_trust_store", false)?
+				.build()?
+				.try_deserialize()?;
+
+			return Ok(config);
+		} else {
+			Ok(opt)
+		}
+	}
+}
+
+#[derive(Debug, Serialize, Deserialize, Parser)]
 pub struct CreateOpt {
 	/// The URL of the MQTT server.
-	#[structopt(env, short, long)]
+	#[arg(short, long, env = "MQTT_URL", default_value = "localhost:1883")]
 	pub url: String,
 
 	/// The client ID useful for session resuming
-	#[structopt(long, default_value)]
+	#[arg(long, env = "MQTT_CLIENT_ID", default_value = "")]
 	pub client_id: String,
 
 	/// The MQTT version
-	#[structopt(long, short = "v", default_value = "5")]
+	#[arg(long, short = 'v', env = "MQTT_VERSION", default_value = "5")]
 	pub mqtt_version: u32,
 }
 
@@ -50,63 +99,63 @@ impl From<CreateOpt> for CreateOptions {
 	}
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Serialize, Deserialize, Parser)]
 pub struct ConnectOpt {
 	/// The keep-alive interval for the client session.
-	#[structopt(long, parse(try_from_str = parse_duration))]
+	#[arg(long, env = "MQTT_KEEP_ALIVE_INTERVAL", value_parser(parse_duration))]
 	pub keep_alive_interval: Option<Duration>,
 
 	/// Sets the 'clean session' flag to send to the broker.
 	///
 	/// This is for MQTT v3.x connections only, and if set, will set the other options to be
 	/// compatible with v3.
-	#[structopt(long)]
+	#[arg(long, env = "MQTT_CLEAN_SESSION")]
 	pub clean_session: bool,
 
 	/// Sets the 'clean start' flag to send to the broker.
 	///
 	/// This is for MQTT v5 connections only, and if set, will set the other options to be compatible
 	/// with v5.
-	#[structopt(long)]
+	#[arg(long, env = "MQTT_CLEAN_START")]
 	pub clean_start: bool,
 
 	/// The maximum number of in-flight messages that can be simultaneously handled by this client.
-	#[structopt(long)]
+	#[arg(long, env = "MQTT_MAX_INFLIGHT")]
 	pub max_inflight: Option<i32>,
 
 	/// The username for authentication with the broker.
-	#[structopt(long, short)]
+	#[arg(long, short, env = "MQTT_USERNAME")]
 	pub username: Option<String>,
 
 	/// The password for authenticaton with the broker.
-	#[structopt(long, short)]
+	#[arg(long, short, env = "MQTT_PASSWORD")]
 	pub password: Option<String>,
 
 	/// The time interval in which to allow the connection to complete.
-	#[structopt(long, parse(try_from_str = parse_duration))]
+	#[arg(long, env = "MQTT_CONNECT_TIMEOUT", value_parser(parse_duration))]
 	pub connect_timeout: Option<Duration>,
 
 	/// The time interval in which to retry connections.
-	#[structopt(long, parse(try_from_str = parse_duration))]
+	#[arg(long, env = "MQTT_RETRY_INTERVAL", value_parser(parse_duration))]
 	pub retry_interval: Option<Duration>,
 
 	/// The minimum interval in which to retry connecting.
-	#[structopt(long, parse(try_from_str = parse_duration), required_if("automatic_reconnect_max", "Option::is_some"))]
+	#[arg(long, env = "MQTT_AUTOMATIC_RECONNECT_MIN", value_parser(parse_duration), requires("automatic_reconnect_max"))]
 	pub automatic_reconnect_min: Option<Duration>,
 
 	/// The maximum interval in which to retry connecting.
-	#[structopt(long, parse(try_from_str = parse_duration), required_if("automatic_reconnect_min", "Option::is_some"))]
+	#[arg(long, env = "MQTT_AUTOMATIC_RECONNECT_MAX", value_parser(parse_duration), requires("automatic_reconnect_min"))]
 	pub automatic_reconnect_max: Option<Duration>,
 
 	/// The HTTP proxy for websockets.
-	#[structopt(long)]
+	#[arg(long, env = "MQTT_HTTP_PROXY")]
 	pub http_proxy: Option<String>,
 
 	/// The HTTPS proxy for websockets.
-	#[structopt(long)]
+	#[arg(long, env = "MQTT_HTTPS_PROXY")]
 	pub https_proxy: Option<String>,
 
-	#[structopt(flatten)]
+	#[command(flatten)]
 	pub ssl: SslOpts,
 }
 
@@ -160,22 +209,22 @@ impl TryFrom<ConnectOpt> for ConnectOptions {
 	}
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Serialize, Deserialize, Parser)]
 pub struct SslOpts {
 	/// Path to the PEM file containing public certificates to trust.
-	#[structopt(long)]
+	#[arg(long, env = "MQTT_TRUST_STORE")]
 	pub trust_store: Option<PathBuf>,
 
 	/// Path to the PEM file containing the public certificate chain.
-	#[structopt(long)]
+	#[arg(long, env = "MQTT_KEY_STORE")]
 	pub key_store: Option<PathBuf>,
 
 	/// Path to the PEM file containing the client's private key if not in the key store.
-	#[structopt(long)]
+	#[arg(long, env = "MQTT_PRIVATE_KEY")]
 	pub private_key: Option<PathBuf>,
 
 	/// The password to load the private key, if encrypted.
-	#[structopt(long)]
+	#[arg(long, env = "MQTT_PRIVATE_KEY_PASSWORD")]
 	pub private_key_password: Option<String>,
 
 	/// The list of cypher suites the client will present to the server during the SSL handshake.
@@ -185,23 +234,23 @@ pub struct SslOpts {
 	///
 	/// If this setting is ommitted, its default value will be “ALL”, that is, all the cipher suites
 	/// -excluding those offering no encryption- will be considered.
-	#[structopt(long)]
-	pub enabled_cypher_suites: Option<String>,
+	#[arg(long, env = "MQTT_ENABLED_CIPHER_SUITES")]
+	pub enabled_cipher_suites: Option<String>,
 
 	/// Whether verification of the server certificate is enabled.
-	#[structopt(long)]
+	#[arg(long, env = "MQTT_ENABLE_SERVER_CERT_AUTH")]
 	pub enable_server_cert_auth: bool,
 
 	/// Whether to perform post connection certificate checks.
-	#[structopt(long)]
+	#[arg(long, env = "MQTT_VERIFY")]
 	pub verify: bool,
 
 	/// Path to the directory containing CA certificates in PEM format.
-	#[structopt(long)]
+	#[arg(long, env = "MQTT_CA_PATH")]
 	pub ca_path: Option<PathBuf>,
 
 	/// Whether to load the default SSL CA.
-	#[structopt(long)]
+	#[arg(long, env = "MQTT_DISABLE_DEFAULT_TRUST_STORE")]
 	pub disable_default_trust_store: bool,
 }
 
@@ -227,7 +276,7 @@ impl TryFrom<SslOpts> for SslOptions {
 			builder = builder.private_key_password(private_key_password);
 		}
 
-		if let Some(enabled_cipher_suites) = opts.enabled_cypher_suites {
+		if let Some(enabled_cipher_suites) = opts.enabled_cipher_suites {
 			builder = builder.enabled_cipher_suites(enabled_cipher_suites);
 		}
 

--- a/brokers/mqtt/src/config.rs
+++ b/brokers/mqtt/src/config.rs
@@ -24,7 +24,7 @@ pub struct Config {
 
 	/// Events to subscribe to.
 	#[arg(short, long, env = "MQTT_EVENTS", value_delimiter = ',')]
-	#[serde(default = "Config::default_events")]
+	#[serde(default)]
 	pub events: Vec<String>,
 
 	/// Quality of Service for sending & receiving messages
@@ -37,10 +37,6 @@ pub struct Config {
 }
 
 impl Config {
-	pub fn default_events() -> Vec<String> {
-		vec![]
-	}
-
 	pub fn default_qos() -> i32 {
 		2
 	}
@@ -78,7 +74,7 @@ pub struct CreateOpt {
 
 	/// The client ID useful for session resuming
 	#[arg(long, env = "MQTT_CLIENT_ID", default_value = "")]
-	#[serde(default = "CreateOpt::default_client_id")]
+	#[serde(default)]
 	pub client_id: String,
 
 	/// The MQTT version
@@ -90,10 +86,6 @@ pub struct CreateOpt {
 impl CreateOpt {
 	pub fn default_url() -> String {
 		"localhost:1883".to_string()
-	}
-
-	pub fn default_client_id() -> String {
-		"".to_string()
 	}
 
 	pub fn default_version() -> u32 {
@@ -122,7 +114,7 @@ pub struct ConnectOpt {
 	/// This is for MQTT v3.x connections only, and if set, will set the other options to be
 	/// compatible with v3.
 	#[arg(long, env = "MQTT_CLEAN_SESSION")]
-	#[serde(default = "ConnectOpt::default_clean_session")]
+	#[serde(default)]
 	pub clean_session: bool,
 
 	/// Sets the 'clean start' flag to send to the broker.
@@ -130,7 +122,7 @@ pub struct ConnectOpt {
 	/// This is for MQTT v5 connections only, and if set, will set the other options to be compatible
 	/// with v5.
 	#[arg(long, env = "MQTT_CLEAN_START")]
-	#[serde(default = "ConnectOpt::default_clean_start")]
+	#[serde(default)]
 	pub clean_start: bool,
 
 	/// The maximum number of in-flight messages that can be simultaneously handled by this client.
@@ -181,16 +173,6 @@ pub struct ConnectOpt {
 
 	#[command(flatten)]
 	pub ssl: SslOpts,
-}
-
-impl ConnectOpt {
-	pub fn default_clean_session() -> bool {
-		false
-	}
-
-	pub fn default_clean_start() -> bool {
-		false
-	}
 }
 
 impl TryFrom<ConnectOpt> for ConnectOptions {
@@ -273,12 +255,12 @@ pub struct SslOpts {
 
 	/// Whether verification of the server certificate is enabled.
 	#[arg(long, env = "MQTT_ENABLE_SERVER_CERT_AUTH")]
-	#[serde(default = "SslOpts::default_enable_server_cert_auth")]
+	#[serde(default)]
 	pub enable_server_cert_auth: bool,
 
 	/// Whether to perform post connection certificate checks.
 	#[arg(long, env = "MQTT_VERIFY")]
-	#[serde(default = "SslOpts::default_verify")]
+	#[serde(default)]
 	pub verify: bool,
 
 	/// Path to the directory containing CA certificates in PEM format.
@@ -287,22 +269,8 @@ pub struct SslOpts {
 
 	/// Whether to load the default SSL CA.
 	#[arg(long, env = "MQTT_DISABLE_DEFAULT_TRUST_STORE")]
-	#[serde(default = "SslOpts::default_disable_default_trust_store")]
+	#[serde(default)]
 	pub disable_default_trust_store: bool,
-}
-
-impl SslOpts {
-	pub fn default_enable_server_cert_auth() -> bool {
-		false
-	}
-
-	pub fn default_verify() -> bool {
-		false
-	}
-
-	pub fn default_disable_default_trust_store() -> bool {
-		false
-	}
 }
 
 impl TryFrom<SslOpts> for SslOptions {

--- a/brokers/redis/Cargo.toml
+++ b/brokers/redis/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.66"
 bytes = "1.2.1"
+clap = { version = "4.0.26", features = ["derive", "env"] }
 config = "0.13.2"
 futures = "0.3.25"
 nanoid = "0.4.0"

--- a/brokers/redis/Cargo.toml
+++ b/brokers/redis/Cargo.toml
@@ -12,7 +12,7 @@ clap = { version = "4.0.26", features = ["derive", "env"] }
 config = "0.13.2"
 futures = "0.3.25"
 nanoid = "0.4.0"
-serde = "1.0.147"
+serde = { version = "1.0.147", features = ["derive"] }
 tokio = { version = "1.21.2", features = ["macros", "rt", "rt-multi-thread", "io-std", "io-util"] }
 spectacles = { version = "0.1.0", path = "../.." }
 bson = "2.4.0"

--- a/brokers/redis/src/config.rs
+++ b/brokers/redis/src/config.rs
@@ -1,0 +1,48 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use clap::{Parser};
+use config;
+
+#[derive(Debug, Serialize, Deserialize, Parser)]
+#[command(name = "spectacles-redis")]
+pub struct Config {
+	#[arg(long, short, env = "REDIS_CONFIG_FILE", exclusive = true)]
+	pub config_file: Option<String>,
+
+	#[arg(long, short, env = "REDIS_ADDRESS", default_value = "localhost:6379")]
+	pub address: String,
+
+	#[arg(long, short, env = "REDIS_GROUP", required_unless_present("config_file"), default_value = "")]
+	pub group: String,
+
+	#[arg(long, short, env = "REDIS_EVENTS", value_delimiter = ',')]
+	pub events: Vec<String>,
+}
+
+impl Config {
+	pub fn build() -> Result<Config> {
+		let opt = Config::parse();
+
+		if let Some(config_file) = opt.config_file {
+			let file_source = config::File::with_name(&config_file)
+				.required(false);
+
+			let env_source = config::Environment::with_prefix("REDIS")
+				.try_parsing(true)
+				.list_separator(",")
+				.with_list_parse_key("events");
+
+			let config: Config = config::Config::builder()
+				.add_source(file_source)
+				.add_source(env_source)
+				.set_default("address", "localhost:6379")?
+				.set_default("events", vec![] as Vec<String>)?
+				.build()?
+				.try_deserialize()?;
+
+			return Ok(config);
+		} else {
+			Ok(opt)
+		}
+	}
+}

--- a/brokers/redis/src/config.rs
+++ b/brokers/redis/src/config.rs
@@ -23,17 +23,13 @@ pub struct Config {
 	pub group: String,
 
 	#[arg(long, short, env = "REDIS_EVENTS", value_delimiter = ',')]
-	#[serde(default = "Config::default_events")]
+	#[serde(default)]
 	pub events: Vec<String>,
 }
 
 impl Config {
 	pub fn default_address() -> String {
 		"localhost:6379".to_string()
-	}
-
-	pub fn default_events() -> Vec<String> {
-		vec![]
 	}
 }
 

--- a/brokers/redis/src/options.rs
+++ b/brokers/redis/src/options.rs
@@ -1,8 +1,0 @@
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct Opt {
-	pub address: String,
-	pub group: String,
-	pub events: Vec<String>,
-}


### PR DESCRIPTION
Update the configurations for the redis and mqtt broker to allow either cli flags or a config file.
To use a config file, the `--config-file <file>` flag can be used.

This pr also uses `clap` instead of `structopt`, as `structopt` has gone into maintenance mode.